### PR TITLE
Add GitHub Skills activity to address missing activity issue

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the GitHub Skills activity that was announced by the principal but was missing from the activity signup system.

## Changes
- Added "GitHub Skills" to the activities dictionary in `app.py`
- Description: Learn practical coding and collaboration skills through GitHub
- Schedule: Wednesdays, 3:30 PM - 5:00 PM  
- Max participants: 25 students
- Part of the GitHub Certifications program to help with college applications

## Resolves
Closes #7

## Time Sensitivity
This is urgent as the principal announced registrations would close by the end of this week. Students can now sign up for this activity.